### PR TITLE
change runParameters.xml to RunParameters.xml

### DIFF
--- a/alto/commands/upload.py
+++ b/alto/commands/upload.py
@@ -73,9 +73,9 @@ def run_command(command: List[str], dry_run: bool) -> None:
 
 def transfer_flowcell(source: str, dest: str, dry_run: bool, lanes: List[str]) -> None:
     run_command(['gsutil', 'cp', '{0}/RunInfo.xml'.format(source), '{0}/RunInfo.xml'.format(dest)], dry_run)
-    assert os.path.exists('{0}/RTAComplete.txt'.format(source)) and os.path.exists('{0}/runParameters.xml'.format(source))
+    assert os.path.exists('{0}/RTAComplete.txt'.format(source)) and os.path.exists('{0}/RunParameters.xml'.format(source))
     run_command(['gsutil', 'cp', '{0}/RTAComplete.txt'.format(source), '{0}/RTAComplete.txt'.format(dest)], dry_run)
-    run_command(['gsutil', 'cp', '{0}/runParameters.xml'.format(source), '{0}/runParameters.xml'.format(dest)], dry_run)
+    run_command(['gsutil', 'cp', '{0}/RunParameters.xml'.format(source), '{0}/RunParameters.xml'.format(dest)], dry_run)
     basecall_string = '{0}/Data/Intensities/BaseCalls'
     if len(lanes) == 1 and lanes[0] == '*':
         # find all lanes


### PR DESCRIPTION
I had to make this change for the latest batch of data.

A better solution would be to allow lowercase `r` or uppercase `R` in the filename.

I haven't tested to see if this pull request would make previous jobs fail, but it probably would.

Without this change, I get this error:

```
Traceback (most recent call last):
  File "/home/ks38/.conda/envs/jupyter/bin/alto", line 11, in <module>
    load_entry_point('altocumulus', 'console_scripts', 'alto')()
  File "/projects/kamil/work/github.com/klarman-cell-observatory/altocumulus/alto/__main__.py", line 19, in main
    cmd.main(command_args)
  File "/projects/kamil/work/github.com/klarman-cell-observatory/altocumulus/alto/commands/run.py", line 122, in main
    not args.no_cache)
  File "/projects/kamil/work/github.com/klarman-cell-observatory/altocumulus/alto/commands/run.py", line 53, in submit_job_to_terra
    alto.upload_to_google_bucket(inputs, workspace, False, bucket_folder, out_json)
  File "/projects/kamil/work/github.com/klarman-cell-observatory/altocumulus/alto/commands/upload.py", line 180, in upload_to_google_bucket
    input_path, is_changed = transfer_sample_sheet(input_path, input_file_to_output_gsurl, gsurl_gen, dry_run)
  File "/projects/kamil/work/github.com/klarman-cell-observatory/altocumulus/alto/commands/upload.py", line 140, in transfer_sample_sheet
    transfer_data(value, sub_gs_url, dry_run = dry_run, flowcells = flowcells)
  File "/projects/kamil/work/github.com/klarman-cell-observatory/altocumulus/alto/commands/upload.py", line 106, in transfer_data
    transfer_flowcell(source, dest, dry_run, lanes)
  File "/projects/kamil/work/github.com/klarman-cell-observatory/altocumulus/alto/commands/upload.py", line 76, in transfer_flowcell
    assert os.path.exists('{0}/RTAComplete.txt'.format(source)) and os.path.exists('{0}/runParameters.xml'.format(source))
AssertionError
```